### PR TITLE
Reload bundle assets when ctrl-z destroys them (fixes issue #11).

### DIFF
--- a/B9_PWings_Fork/StaticWingGlobals.cs
+++ b/B9_PWings_Fork/StaticWingGlobals.cs
@@ -38,11 +38,17 @@ namespace WingProcedural
             }
         }
 
+		public static bool loadingAssets = false;
+		public static StaticWingGlobals Instance;
+
         private void Awake()
         {
             _bundlePath = KSPUtil.ApplicationRootPath + "GameData" +
                                                     Path.DirectorySeparatorChar +
                                                     "B9_Aerospace_ProceduralWings" + Path.DirectorySeparatorChar + "AssetBundles";
+
+			if (Instance != null) Destroy(Instance);
+			Instance = this;
         }
 
         public void Start()

--- a/B9_PWings_Fork/WingProcedural.cs
+++ b/B9_PWings_Fork/WingProcedural.cs
@@ -3989,6 +3989,13 @@ namespace WingProcedural
 
         private void UpdateHandleGizmos()
         {
+			// Undoing in the Editor destroys all the handle gizmos.
+			if (StaticWingGlobals.handlesRoot == null)
+			{
+				if (StaticWingGlobals.loadingAssets) return;
+				Debug.Log($"[B9_PWings_Fork.WingProcedural]: Reloading Bundle Assets");
+				StartCoroutine(StaticWingGlobals.Instance.LoadBundleAssets());
+			}
             if (!uiEditMode)
             {
                 if (handlesEnabled)


### PR DESCRIPTION
As the title says, this fixes issue #11.