### PR TITLE
Enforce limits on thickness, root width and edge types

### DIFF
--- a/B9_PWings_Fork/UIUtility.cs
+++ b/B9_PWings_Fork/UIUtility.cs
@@ -535,6 +535,7 @@ namespace WingProcedural
             if (!numericInput)
             {
                 value = Mathf.Round((float)value01 * range) + min;
+                value = Mathf.Clamp(value, min, max);
                 GUI.Label(rectLabelValue, GetValueTranslation(value, valueType), UIUtility.uiStyleLabelHint); // slider value
             }
             else

--- a/B9_PWings_Fork/UIUtility.cs
+++ b/B9_PWings_Fork/UIUtility.cs
@@ -442,7 +442,7 @@ namespace WingProcedural
             GUI.Label(rectSlider, $"  {name}", UIUtility.uiStyleLabelHint); // slider name
             if (!numericInput)
             {
-                value = Mathf.Clamp((float)(value01 * range + limits.x), Mathf.Min((float)(limits.x * 0.5), limits.x), limits.y); // lower limit is halved so the fine control can reduce it further but the normal tweak still snaps. Min makes -ve values work
+                value = Mathf.Clamp((float)(value01 * range + limits.x), limits.x, limits.y);
 
                 GUI.Label(rectLabelValue, GetValueTranslation(value, valueType), UIUtility.uiStyleLabelHint); // slider value
             }
@@ -456,7 +456,7 @@ namespace WingProcedural
                         value01 = (value - limits.x) / range;
                     }
                     else
-                        value = Mathf.Clamp((float)(value01 * range + limits.x), Mathf.Min((float)(limits.x * 0.5), limits.x), limits.y); // lower limit is halved so the fine control can reduce it further but the normal tweak still snaps. Min makes -ve values work
+                        value = Mathf.Clamp((float)(value01 * range + limits.x), limits.x, limits.y);
                 }
                 value = Mathf.Clamp(value, limits.x, limits.y);
             }

--- a/B9_PWings_Fork/WingProcedural.cs
+++ b/B9_PWings_Fork/WingProcedural.cs
@@ -135,10 +135,10 @@ namespace WingProcedural
             return isCtrlSrf ? incrementCtrl : incrementWing;
         }
 
-        private static Vector4 sharedBaseLengthLimits = new Vector4(0.0f, 40f, 0.05f, 20f);
-        private static Vector2 sharedBaseThicknessLimits = new Vector2(0.0f, 4f);
-        private static Vector4 sharedBaseWidthRootLimits = new Vector4(0.0f, 40f, 0.05f, 2f);
-        private static Vector4 sharedBaseWidthTipLimits = new Vector4(0.0f, 40f, 0.05f, 2f);
+        private static Vector4 sharedBaseLengthLimits = new Vector4(0.0f, 40f, 0.0f, 20f);
+        private static Vector2 sharedBaseThicknessLimits = new Vector2(0.01f, 4f);
+        private static Vector4 sharedBaseWidthRootLimits = new Vector4(0.01f, 40f, 0.01f, 2f);
+        private static Vector4 sharedBaseWidthTipLimits = new Vector4(0.0f, 40f, 0.0f, 2f);
         private static Vector4 sharedBaseOffsetLimits = new Vector4(-10f, 10f, -1.5f, 1.5f);
         private static Vector4 sharedEdgeTypeLimits = new Vector4(1f, 4f, 1f, 3f);
         private static Vector4 sharedEdgeWidthLimits = new Vector4(0f, 6f, 0f, 6f);
@@ -172,7 +172,6 @@ namespace WingProcedural
 
         public float sharedBaseWidthRootCached = 4f;
         public static Vector4 sharedBaseWidthRootDefaults = new Vector4(4f, 0.5f, 4f, 0.5f);
-        public int sharedBaseWidthRInt = 0;
         [KSPField(isPersistant = true, guiActiveEditor = false, guiActive = false, guiName = "Width (tip)", guiFormat = "S4")]
         public float sharedBaseWidthTip = 4f;
 
@@ -196,13 +195,11 @@ namespace WingProcedural
 
         public float sharedBaseThicknessRootCached = 0.24f;
         public static Vector4 sharedBaseThicknessRootDefaults = new Vector4(0.24f, 0.24f, 0.24f, 0.24f);
-        public int sharedBaseThicknessRInt = 0;
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "Thickness (tip)", guiFormat = "F3")]
         public float sharedBaseThicknessTip = 0.24f;
 
         public float sharedBaseThicknessTipCached = 0.24f;
         public static Vector4 sharedBaseThicknessTipDefaults = new Vector4(0.24f, 0.24f, 0.24f, 0.24f);
-        public int sharedBaseThicknessTInt = 0;
         #endregion Shared properties / Base
 
         #region Shared properties / Edge / Leading
@@ -3201,7 +3198,7 @@ namespace WingProcedural
                     DrawField(ref sharedBaseLength, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseLengthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000014"), uiColorSliderBase, 0, 0, ref sharedBaseLengthInt);		// #autoLOC_B9_Aerospace_WingStuff_1000014 = Length
                     if (!sharedPropAnglePref)
                     {
-                        DrawField(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000015"), uiColorSliderBase, 1, 0, ref sharedBaseWidthRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000015 = Width (root)
+                        DrawLimited(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), GetLimitsFromType(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000015"), uiColorSliderBase, 1, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000015 = Width (root)
                         DrawField(ref sharedBaseWidthTip, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthTipLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000016"), uiColorSliderBase, 2, 0, ref sharedBaseWidthTInt, true);		// #autoLOC_B9_Aerospace_WingStuff_1000016 = Width (tip)
                         DrawOffset(ref sharedBaseOffsetTip, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseOffsetLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000017"), uiColorSliderBase, 4, 0, ref sharedBaseOffsetTInt, true);		// #autoLOC_B9_Aerospace_WingStuff_1000017 = Offset (tip)
                     }
@@ -3219,23 +3216,23 @@ namespace WingProcedural
                         }
                         else if (!sharedPropLockPref)
                         {
-                            DrawField(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000015"), uiColorSliderBase, 1, 0, ref sharedBaseWidthRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000015 = Width (root)
+                            DrawLimited(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), GetLimitsFromType(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000015"), uiColorSliderBase, 1, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000015 = Width (root)
                         }
                     }
 
-                    DrawField(ref sharedBaseThicknessRoot, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000020"), uiColorSliderBase, 5, 0, ref sharedBaseThicknessRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000020 = Thickness (root)
-                    DrawField(ref sharedBaseThicknessTip, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000021"), uiColorSliderBase, 6, 0, ref sharedBaseThicknessTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000021 = Thickness (tip)
+                    DrawLimited(ref sharedBaseThicknessRoot, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), sharedBaseThicknessLimits, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000020"), uiColorSliderBase, 5, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000020 = Thickness (root)
+                    DrawLimited(ref sharedBaseThicknessTip, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), sharedBaseThicknessLimits, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000021"), uiColorSliderBase, 6, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000021 = Thickness (tip)
                     //Debug.Log("B9PW: base complete");
                 }
                 else if (sharedFieldGroupBaseStatic & isCtrlSrf)
                 {
                     DrawField(ref sharedBaseLength, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseLengthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000022"), uiColorSliderBase, 0, 0, ref sharedBaseLengthInt);		// #autoLOC_B9_Aerospace_WingStuff_1000022 = Length
-                    DrawField(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000023"), uiColorSliderBase, 1, 0, ref sharedBaseWidthRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000023 = Width (root)
+                    DrawLimited(ref sharedBaseWidthRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthRootLimits), GetLimitsFromType(sharedBaseWidthRootLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000023"), uiColorSliderBase, 1, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000023 = Width (root)
                     DrawField(ref sharedBaseWidthTip, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseWidthTipLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000024"), uiColorSliderBase, 2, 0, ref sharedBaseWidthTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000024 = Width (tip)
                     DrawOffset(ref sharedBaseOffsetRoot, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseOffsetLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000025"), uiColorSliderBase, 3, 0, ref sharedBaseOffsetRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000025 = Offset (root)
                     DrawOffset(ref sharedBaseOffsetTip, GetIncrementFromType(sharedIncrementMain, sharedIncrementSmall), GetStep(sharedBaseOffsetLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000026"), uiColorSliderBase, 4, 0, ref sharedBaseOffsetTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000026 = Offset (tip)
-                    DrawField(ref sharedBaseThicknessRoot, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000027"), uiColorSliderBase, 5, 0, ref sharedBaseThicknessRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000027 = Thickness (root)
-                    DrawField(ref sharedBaseThicknessTip, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000028"), uiColorSliderBase, 6, 0, ref sharedBaseThicknessTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000028 = Thickness (tip)
+                    DrawLimited(ref sharedBaseThicknessRoot, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), sharedBaseThicknessLimits, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000027"), uiColorSliderBase, 5, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000027 = Thickness (root)
+                    DrawLimited(ref sharedBaseThicknessTip, sharedIncrementSmall, GetStep2(sharedBaseThicknessLimits), sharedBaseThicknessLimits, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000028"), uiColorSliderBase, 6, 0);		// #autoLOC_B9_Aerospace_WingStuff_1000028 = Thickness (tip)
                 }
 
                 if (!isCtrlSrf)
@@ -3452,7 +3449,6 @@ namespace WingProcedural
         /// <param name="field">the value to draw</param>
         /// <param name="increment">mouse drag increment</param>
         /// <param name="incrementLarge">button increment</param>
-        /// <param name="limits">min/max value</param>
         /// <param name="name">the field name to display</param>
         /// <param name="hsbColor">field colour</param>
         /// <param name="fieldID">tooltip stuff</param>
@@ -3460,65 +3456,45 @@ namespace WingProcedural
         /// <param name="allowFine">Whether right click drag behaves as fine control or not</param>
         private void DrawField(ref float field, float increment, float step, string name, Vector4 hsbColor, int fieldID, int fieldType, ref int delta, bool allowFine = true)
         {
-            float Cached = field;
+            float cached = field;
             field = UIUtility.FieldSlider(field, increment, step, name, out bool changed, ColorHSBToRGB(hsbColor), fieldType, ref delta, allowFine);
 
             if (changed)
             {
-                uiLastFieldName = name;
-                uiLastFieldTooltip = UpdateTooltipText(fieldID);
-                if (fieldID == 5 & sharedPropEThickPref)
-                {
-                    if (Cached == 0)
-                        Cached = field;
-                    sharedEdgeWidthLeadingRoot *= field / Cached;
-                    sharedEdgeWidthTrailingRoot *= field / Cached;
-                }
-                else if (fieldID == 6 & sharedPropEThickPref)
-                {
-                    if (Cached == 0)
-                        Cached = field;
-                    sharedEdgeWidthLeadingTip *= field / Cached;
-                    sharedEdgeWidthTrailingTip *= field / Cached;
-                }
+                HandleFieldValueChange(field, name, fieldID, cached);
             }
         }
 
         private void DrawOffset(ref float field, float increment, float range, string name, Vector4 hsbColor, int fieldID, int fieldType, ref int delta, bool allowFine = true)
         {
+            float cached = field;
             field = UIUtility.OffsetSlider(field, increment, range, name, out bool changed, ColorHSBToRGB(hsbColor), fieldType, ref delta, allowFine);
 
             if (changed)
             {
-                uiLastFieldName = name;
-                uiLastFieldTooltip = UpdateTooltipText(fieldID);
-                //Debug.Log("B9PW:" + name  + " Value changed to " + field);
+                HandleFieldValueChange(field, name, fieldID, cached);
             }
         }
+
         private void DrawLimited(ref float field, float increment, float incrementLarge, Vector2 limits, string name, Vector4 hsbColor, int fieldID, int fieldType, bool allowFine = true)
         {
+            float cached = field;
             field = UIUtility.LimitedSlider(field, increment, incrementLarge, limits, name, out bool changed, ColorHSBToRGB(hsbColor), fieldType, allowFine);
 
             if (changed)
             {
-                uiLastFieldName = name;
-                uiLastFieldTooltip = UpdateTooltipText(fieldID);
-                //Debug.Log("B9PW:" + name  + " Value changed to " + field);
-                if (fieldID == 201 || fieldID == 202)
-                {
-                    CalcBase(fieldID);
-                }
+                HandleFieldValueChange(field, name, fieldID, cached);
             }
         }
+
         private void DrawInt(ref float field, float incrementLarge, int min, int max, string name, Vector4 hsbColor, int fieldID, int fieldType, bool allowFine = true)
         {
+            float cached = field;
             field = UIUtility.IntegerSlider(field, incrementLarge, min, max, name, out bool changed, ColorHSBToRGB(hsbColor), fieldType, allowFine);
 
             if (changed)
             {
-                uiLastFieldName = name;
-                uiLastFieldTooltip = UpdateTooltipText(fieldID);
-                //Debug.Log("B9PW:" + name  + " Value changed to " + field);
+                HandleFieldValueChange(field, name, fieldID, cached);
             }
         }
 
@@ -3535,6 +3511,30 @@ namespace WingProcedural
                     sharedSweptAngleFront = CalcAngleFront();
                 }
                 //Debug.Log("B9PW:" + value + " Value changed to " + value);
+            }
+        }
+
+        private void HandleFieldValueChange(float field, string name, int fieldID, float cached)
+        {
+            uiLastFieldName = name;
+            uiLastFieldTooltip = UpdateTooltipText(fieldID);
+            if (fieldID == 5 & sharedPropEThickPref)
+            {
+                if (cached == 0)
+                    cached = field;
+                sharedEdgeWidthLeadingRoot *= field / cached;
+                sharedEdgeWidthTrailingRoot *= field / cached;
+            }
+            else if (fieldID == 6 & sharedPropEThickPref)
+            {
+                if (cached == 0)
+                    cached = field;
+                sharedEdgeWidthLeadingTip *= field / cached;
+                sharedEdgeWidthTrailingTip *= field / cached;
+            }
+            else if (fieldID == 201 || fieldID == 202)
+            {
+                CalcBase(fieldID);
             }
         }
 
@@ -3800,7 +3800,7 @@ namespace WingProcedural
                         sharedBaseThicknessTip += diff.x * Vector3.Dot(EditorCamera.Instance.GetComponent<Camera>().transform.right, -part.transform.forward) + diff.y * Vector3.Dot(EditorCamera.Instance.GetComponent<Camera>().transform.up, part.transform.forward * (part.isMirrored ? 1 : -1));
                         sharedEdgeWidthLeadingTip *= sharedBaseThicknessTip / tipThicknessCatched;
                         sharedEdgeWidthTrailingTip *= sharedBaseThicknessTip / tipThicknessCatched;
-                        //sharedBaseThicknessTip = Mathf.Clamp(sharedBaseThicknessTip, sharedBaseThicknessLimits.x, sharedBaseThicknessLimits.y);
+                        sharedBaseThicknessTip = Mathf.Clamp(sharedBaseThicknessTip, sharedBaseThicknessLimits.x, sharedBaseThicknessLimits.y);
 
                         sharedEdgeWidthLeadingTip += diff.x * Vector3.Dot(EditorCamera.Instance.GetComponentCached<Camera>(ref editorCam).transform.right, part.transform.up) + diff.y * Vector3.Dot(EditorCamera.Instance.GetComponentCached<Camera>(ref editorCam).transform.up, part.transform.up);
                         sharedEdgeWidthLeadingTip = Mathf.Clamp(sharedEdgeWidthLeadingTip, GetLimitsFromType(sharedEdgeWidthLimits).x, GetLimitsFromType(sharedEdgeWidthLimits).y);
@@ -4126,13 +4126,13 @@ namespace WingProcedural
                         default: break;
                     }
                 }
-                sharedBaseLength = sharedBaseLength > 0 ? sharedBaseLength : 0;
+                sharedBaseLength = Mathf.Clamp(sharedBaseLength, GetLimitsFromType(sharedBaseLengthLimits).x, GetLimitsFromType(sharedBaseLengthLimits).y);
                 sharedEdgeWidthLeadingRoot = sharedEdgeWidthLeadingRoot > 0 ? sharedEdgeWidthLeadingRoot : 0;
                 sharedEdgeWidthLeadingTip = sharedEdgeWidthLeadingTip > 0 ? sharedEdgeWidthLeadingTip : 0;
                 sharedEdgeWidthTrailingRoot = sharedEdgeWidthTrailingRoot > 0 ? sharedEdgeWidthTrailingRoot : 0;
                 sharedEdgeWidthTrailingTip = sharedEdgeWidthTrailingTip > 0 ? sharedEdgeWidthTrailingTip : 0;
-                sharedBaseWidthRoot = sharedBaseWidthRoot > 0 ? sharedBaseWidthRoot : 0;
-                sharedBaseWidthTip = sharedBaseWidthTip > 0 ? sharedBaseWidthTip : 0;
+                sharedBaseWidthRoot = Mathf.Clamp(sharedBaseWidthRoot, GetLimitsFromType(sharedBaseWidthRootLimits).x, GetLimitsFromType(sharedBaseWidthRootLimits).y);
+                sharedBaseWidthTip = Mathf.Clamp(sharedBaseWidthTip, GetLimitsFromType(sharedBaseWidthTipLimits).x, GetLimitsFromType(sharedBaseWidthTipLimits).y);
 
                 if (prev_sharedBaseLength != sharedBaseLength)
                 { uiLastFieldName = Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000148"); lastFieldID = 0; }		// #autoLOC_B9_Aerospace_WingStuff_1000148 = Length

--- a/B9_PWings_Fork/WingProcedural.cs
+++ b/B9_PWings_Fork/WingProcedural.cs
@@ -3240,7 +3240,8 @@ namespace WingProcedural
                     DrawFieldGroupHeader(ref sharedFieldGroupEdgeLeadingStatic, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000029"));		// #autoLOC_B9_Aerospace_WingStuff_1000029 = Edge (leading)
                     if (sharedFieldGroupEdgeLeadingStatic)
                     {
-                        DrawInt(ref sharedEdgeTypeLeading, sharedIncrementInt, 1, 4, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000030"), uiColorSliderEdgeL, 7, 2);		// #autoLOC_B9_Aerospace_WingStuff_1000030 = Shape
+                        Vector2 edgeLimits = GetLimitsFromType(sharedEdgeTypeLimits);
+                        DrawInt(ref sharedEdgeTypeLeading, sharedIncrementInt, (int)edgeLimits.x, (int)edgeLimits.y, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000030"), uiColorSliderEdgeL, 7, 2);		// #autoLOC_B9_Aerospace_WingStuff_1000030 = Shape
                         DrawField(ref sharedEdgeWidthLeadingRoot, sharedIncrementSmall, GetStep(sharedEdgeWidthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000031"), uiColorSliderEdgeL, 8, 0, ref sharedEdgeWidthLRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000031 = Width (root)
                         DrawField(ref sharedEdgeWidthLeadingTip, sharedIncrementSmall, GetStep(sharedEdgeWidthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000032"), uiColorSliderEdgeL, 9, 0, ref sharedEdgeWidthLTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000032 = Width (tip)
                     }
@@ -3250,7 +3251,8 @@ namespace WingProcedural
                 DrawFieldGroupHeader(ref sharedFieldGroupEdgeTrailingStatic, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000033"));		// #autoLOC_B9_Aerospace_WingStuff_1000033 = Edge (trailing)
                 if (sharedFieldGroupEdgeTrailingStatic)
                 {
-                    DrawInt(ref sharedEdgeTypeTrailing, sharedIncrementInt, 1, 4, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000034"), uiColorSliderEdgeT, 10, isCtrlSrf ? 3 : 2);		// #autoLOC_B9_Aerospace_WingStuff_1000034 = Shape
+                    Vector2 edgeLimits = GetLimitsFromType(sharedEdgeTypeLimits);
+                    DrawInt(ref sharedEdgeTypeTrailing, sharedIncrementInt, (int)edgeLimits.x, (int)edgeLimits.y, Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000034"), uiColorSliderEdgeT, 10, isCtrlSrf ? 3 : 2);		// #autoLOC_B9_Aerospace_WingStuff_1000034 = Shape
                     DrawField(ref sharedEdgeWidthTrailingRoot, sharedIncrementSmall, GetStep(sharedEdgeWidthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000035"), uiColorSliderEdgeT, 11, 0, ref sharedEdgeWidthTRInt);		// #autoLOC_B9_Aerospace_WingStuff_1000035 = Width (root)
                     DrawField(ref sharedEdgeWidthTrailingTip, sharedIncrementSmall, GetStep(sharedEdgeWidthLimits), Localizer.Format("#autoLOC_B9_Aerospace_WingStuff_1000036"), uiColorSliderEdgeT, 12, 0, ref sharedEdgeWidthTTInt);		// #autoLOC_B9_Aerospace_WingStuff_1000036 = Width (tip)
                 }
@@ -3391,11 +3393,11 @@ namespace WingProcedural
             sharedBaseOffsetRoot = SetupFieldValue(sharedBaseOffsetRoot, nolimit, GetDefault(sharedBaseOffsetRootDefaults));
             sharedBaseOffsetTip = SetupFieldValue(sharedBaseOffsetTip, nolimit, GetDefault(sharedBaseOffsetTipDefaults));
 
-            sharedEdgeTypeTrailing = SetupFieldValue(sharedEdgeTypeTrailing, sharedEdgeTypeLimits, GetDefault(sharedEdgeTypeTrailingDefaults));
+            sharedEdgeTypeTrailing = SetupFieldValue(sharedEdgeTypeTrailing, GetLimitsFromType(sharedEdgeTypeLimits), GetDefault(sharedEdgeTypeTrailingDefaults));
             sharedEdgeWidthTrailingRoot = SetupFieldValue(sharedEdgeWidthTrailingRoot, positiveinf, GetDefault(sharedEdgeWidthTrailingRootDefaults));
             sharedEdgeWidthTrailingTip = SetupFieldValue(sharedEdgeWidthTrailingTip, positiveinf, GetDefault(sharedEdgeWidthTrailingTipDefaults));
 
-            sharedEdgeTypeLeading = SetupFieldValue(sharedEdgeTypeLeading, sharedEdgeTypeLimits, GetDefault(sharedEdgeTypeLeadingDefaults));
+            sharedEdgeTypeLeading = SetupFieldValue(sharedEdgeTypeLeading, GetLimitsFromType(sharedEdgeTypeLimits), GetDefault(sharedEdgeTypeLeadingDefaults));
             sharedEdgeWidthLeadingRoot = SetupFieldValue(sharedEdgeWidthLeadingRoot, positiveinf, GetDefault(sharedEdgeWidthLeadingRootDefaults));
             sharedEdgeWidthLeadingTip = SetupFieldValue(sharedEdgeWidthLeadingTip, positiveinf, GetDefault(sharedEdgeWidthLeadingTipDefaults));
 


### PR DESCRIPTION
There used to be limits originally but they broke in one of the many forks. This in turn introduced issues where vessels spawn 1k above the terrain or cause crashes due to part mass going NaN.

I also removed the weird logic that allowed "fine tuning mode" to go 2x smaller than the limit. No idea why something like that even existed.

Fixes #14 